### PR TITLE
docs: fix root README code fence

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Alternatively, clone the repository locally:
 git clone https://github.com/CodeWithEugene/career-roadmaps
 cd career-roadmaps
 
-```bash
 # Navigate to your career folder
 cd <career-folder>
 


### PR DESCRIPTION
## Summary
- remove an extra nested ```bash fence from the root README clone instructions
- keep the existing commands/content unchanged so the section renders as one bash block

## Validation
- `python3` README fence-structure assertion
- `git diff --check`

Fixes #3.
